### PR TITLE
implement *WithDelimiter funcs

### DIFF
--- a/ns_test.go
+++ b/ns_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/odeke-em/namespace"
+	"github.com/orijtech/namespace"
 )
 
 func TestParse(t *testing.T) {
@@ -37,6 +37,74 @@ func TestParse(t *testing.T) {
 	for i, tt := range tests {
 		r := strings.NewReader(tt.text)
 		ns, err := namespace.Parse(r)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d: err=nil", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err=%v", i, err)
+			continue
+		}
+
+		gotBlob, _ := json.MarshalIndent(ns, "", "  ")
+		wantBlob, _ := json.MarshalIndent(tt.want, "", "  ")
+		if !bytes.Equal(gotBlob, wantBlob) {
+			t.Errorf("got: %s\nwant: %s", gotBlob, wantBlob)
+		}
+	}
+}
+
+func TestParseWithDelimiter(t *testing.T) {
+	tests := [...]struct {
+		text     string
+		hdrDelim string
+		wantErr  bool
+		want     namespace.Namespace
+	}{
+		0: {
+			hdrDelim: ",",
+			text: `[]
+				key1=value2
+
+				[    ]
+				k2=v2
+
+				[push/pull////,pull]
+				k2=v2
+				[pull]
+				kp2=vp2`,
+			want: namespace.Namespace{
+				"global":        []string{"key1=value2", "k2=v2"},
+				"push/pull////": []string{"k2=v2"},
+				"pull":          []string{"k2=v2", "kp2=vp2"},
+			},
+		},
+		1: {
+			hdrDelim: "|",
+			text: `[]
+				key1=value2
+
+				[    ]
+				k2=v2
+
+				[push|pull]
+				k2=v2
+				[pull]
+				kp2=vp2`,
+			want: namespace.Namespace{
+				"global": []string{"key1=value2", "k2=v2"},
+				"push":   []string{"k2=v2"},
+				"pull":   []string{"k2=v2", "kp2=vp2"},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		r := strings.NewReader(tt.text)
+		ns, err := namespace.ParseWithHeaderDelimiter(r, tt.hdrDelim)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("#%d: err=nil", i)


### PR DESCRIPTION
Allow custom *WithDelimiter functionality.
The purpose of this is to be able to perform
routing e.g with frontend servers for which
"/" cannot be the default delimiter.